### PR TITLE
Fix Extension Activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "categories": [
         "Formatters"
     ],
+    "activationEvents": [
+        "onLanguage:java"
+    ],
     "main": "./dist/extension.js",
     "contributes": {
         "configuration": [
@@ -36,14 +39,6 @@
                         "scope": "window"
                     }
                 }
-            }
-        ],
-        "languages": [
-            {
-                "id": "java",
-                "extensions": [
-                    ".java"
-                ]
             }
         ]
     },


### PR DESCRIPTION
Removed the Java language contribution and replaced with it the Java language activation event. This allows the extension to be properly activated in VS Code v1.78.