### PR TITLE
fix: add quotation marks around jarfile in GoogleJavaFormatterSync.ts

### DIFF
--- a/src/GoogleJavaFormatterSync.ts
+++ b/src/GoogleJavaFormatterSync.ts
@@ -16,7 +16,7 @@ export default class GoogleJavaFormatterSync implements IGoogleJavaFormatter {
         return new Promise<string>((resolve, reject) => {
             try {
                 const stdout: string = execSync(
-                    `java -jar ${this.executable} ${this.extra ?? ""} -`,
+                    `java -jar "${this.executable}" ${this.extra ?? ""} -`,
                     {
                         encoding: "utf8",
                         input: text,


### PR DESCRIPTION
My friend is running into issues running this extension as their user profile folder on Windows contains a space character.

The extension throws the following error:
`Command failed: java -jar c:\Users\Their Name\.vscode\extensions\<extension folder>\cache\google-java-format-<version>-all-deps.jar - Error: Unable to access jarfile c:\Users\Their`

Note that everything after the first word in their name is cut off due to the space in their user profile folder.

This patch adds quotation marks around `${this.executable}` in `src/GoogleJavaFormatterSync.ts`.
This fixes issues running the Google Java Format jar when the jar is located directory with a path that has spaces.