### PR TITLE
Document "jar-file" option on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This extension contributes the following settings:
 
 * `java.format.settings.google.executable`: *Not Recommended.* Specifies url or file path to [Google Java Format jar executable](https://github.com/google/google-java-format/releases). Overrides `java.format.settings.google.version`.
 * `java.format.settings.google.version`: *Recommended.* Specifies version to be used of [Google Java Format executable](https://github.com/google/google-java-format/releases) in format `{major}.{minor}.{patch}`. Default: `latest`.
-* `java.format.settings.google.mode`: Specifies the runtime mode of [Google Java Format](https://github.com/google/google-java-format/releases). Used with `java.format.settings.google.version`. Default: `native-binary`.
+* `java.format.settings.google.mode`: Specifies the runtime mode of [Google Java Format](https://github.com/google/google-java-format/releases). Used with `java.format.settings.google.version`. Default: `native-binary`, alternative: `jar-file`.
 * `java.format.settings.google.extra`: Extra CLI arguments to pass to [Google Java Format](https://github.com/google/google-java-format).
 
 Please refer [Google Java Format repository](https://github.com/google/google-java-format) for available versions and CLI arguments.


### PR DESCRIPTION
Motivated by https://github.com/google/google-java-format/issues/1072